### PR TITLE
fix case when credit has a leading zero

### DIFF
--- a/dellmont-credit-checker.sh
+++ b/dellmont-credit-checker.sh
@@ -202,7 +202,9 @@ check_credit_level() {
 				local PREVCREDIT=("2000-01-01 00:00 0")
 			fi
 			echo -e "`date +"%Y-%m-%d %T"`\t$CREDITCENTS">>"$6"
-			local CREDITFALL=$((${PREVCREDIT[2]}-$CREDITCENTS))
+			# remove leading spaces if any, and add 10# so to make it work with credit like: "093" " 201"
+			temp_var=`echo $CREDITCENTS | sed -e 's/^[ \t]*//'`
+                        local CREDITFALL=$((10#${PREVCREDIT[2]}-10#$temp_var))
 			[ -n "$DEBUG" ] && echo -en "Previous credit   : '${PREVCREDIT[2]}' at ${PREVCREDIT[0]} ${PREVCREDIT[1]}\nCredit Reduction  : '$CREDITFALL'"
 			if [ $CREDITFALL -gt $5 ]; then
 				send_message "Credit Reduction Warning - $1\nThe credit on your $1 account '$2' stands at ${CREDITCENTS:0:$((${#CREDITCENTS}-2))}.${CREDITCENTS:(-2):2}, and has fallen by ${CREDITFALL:0:$((${#CREDITFALL}-2))}.${CREDITFALL:(-2):2} since ${PREVCREDIT[0]} ${PREVCREDIT[1]}."


### PR DESCRIPTION
Prepend the string "10#" to the front forces bash to treat them as decimal, even though the leading zero would normally make them octal.
Adding this prefix imply the credit cannot have leading spaces

p.s. Which version? I downloaded hour code today from http://www.timedicer.co.uk/programs/dellmont-credit-checker.sh  (on centos 6)
